### PR TITLE
fix: settings item not showing and not being injected into the correct section

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,8 @@ on:
     push:
         branches: [master]
 
+    workflow_dispatch:
+
 jobs:
     deploy:
         runs-on: ubuntu-latest

--- a/plugins/MoreAlts/SidebarPatcher.js
+++ b/plugins/MoreAlts/SidebarPatcher.js
@@ -141,17 +141,15 @@ function patchTabsUI(tabs, patches) {
                     const [config] = args;
                     const sections = config.sections;
 
-                    const section = sections?.find((x) => {
-                        ["Bunny", "Kettu", "Revenge"].some(
-                            mod => x.label === mod && x.title === mod
-                        )
-                    });
+                    const section = sections?.find((x) =>
+                        ["Bunny", "Kettu", "Revenge"].includes(x?.label)
+                    );
 
                     // If unable to find a section
                     if(!section) {
                         const isMainSettings = Boolean(
                             sections?.find((x) => 
-                                x.settings[0] == "PREMIUM"
+                                x.settings.includes("ACCOUNT")
                             )
                         )
                         
@@ -182,17 +180,15 @@ function patchTabsUI(tabs, patches) {
                     i => i.props?.sections,
                 ).props;
                 
-                const section = sections?.find((x) =>
-                    ["Bunny", "Kettu", "Revenge"].some(
-                        mod => x.label === mod && x.title === mod,
-                    )
+                const section = sections?.find((x) => 
+                    ["Bunny", "Kettu", "Revenge"].includes(x?.label)
                 );
 
                 // If unable to find a section
                     if(!section) {
                         const isMainSettings = Boolean(
                             sections?.find((x) => 
-                                x.settings[0] == "PREMIUM"
+                                x.settings.includes("ACCOUNT")
                             )
                         )
                         


### PR DESCRIPTION
This PR fixes an issue with the last one ( #1 ) where the settings item would not find the Revenge settings section (or similar) and would instead try to insert it at the top. It also fixes another issue where if it is unable to find the correct section, nitro users would have it not be injected at all (had to do with finding if it is the correct settings page, it used to check for the "Get Nitro" item which would not be there for nitro users).